### PR TITLE
Fix missing provider error when trying to update a hostname

### DIFF
--- a/lib/WWW/Codeguard.pm
+++ b/lib/WWW/Codeguard.pm
@@ -13,11 +13,11 @@ WWW::Codeguard - Perl interface to interact with the Codeguard API
 
 =head1 VERSION
 
-Version 0.09
+Version 0.11
 
 =cut
 
-our $VERSION = '0.10';
+our $VERSION = '0.11';
 
 =head1 SYNOPSIS
 

--- a/lib/WWW/Codeguard/User.pm
+++ b/lib/WWW/Codeguard/User.pm
@@ -877,7 +877,7 @@ sub _fetch_optional_params {
 	my $optional_keys_map = {
         create_website        => { map { ($_ => 1) } qw(port dir_path) },
         create_database       => { map { ($_ => 1) } qw(website_id authentication_mode) },
-        edit_website          => { map { ($_ => 1) } qw(url monitor_frequency account password key dir_path hostname disabled) },
+        edit_website          => { map { ($_ => 1) } qw(url monitor_frequency account password key dir_path hostname disabled provider) },
         show_database         => { map { ($_ => 1) } qw(website_id) }, # Added in v0.03.
         edit_database         => { map { ($_ => 1) } qw(server_address account password port database_name authentication_mode server_account server_password website_id disabled) },
         browse_website_backup => { map { ($_ => 1) } qw (path) },

--- a/lib/WWW/Codeguard/User.pm
+++ b/lib/WWW/Codeguard/User.pm
@@ -181,6 +181,7 @@ Optional:
 	dir_path
 	hostname
 	disabled
+	provider
 
 =cut
 


### PR DESCRIPTION
provider is required to update the hostname... but this code strips the provider from the list

This change prevents the provider from being stripped out of the request.